### PR TITLE
add candidate model api

### DIFF
--- a/lib/api/conduct/network/snapshot.rb
+++ b/lib/api/conduct/network/snapshot.rb
@@ -4,6 +4,7 @@ require 'grape'
 require_relative 'snapshot/subsets'
 require_relative 'snapshot/splice_topology'
 require_relative 'snapshot/topology'
+require_relative 'snapshot/candidate_topology'
 
 module ModelConductor
   module ApiRoute
@@ -16,6 +17,7 @@ module ModelConductor
         mount ApiRoute::Subsets
         mount ApiRoute::SpliceTopology
         mount ApiRoute::Topology
+        mount ApiRoute::CandidateTopology
       end
     end
   end

--- a/lib/api/conduct/network/snapshot/candidate_topology.rb
+++ b/lib/api/conduct/network/snapshot/candidate_topology.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'grape'
+
+module ModelConductor
+  module ApiRoute
+    class CandidateTopology < Grape::API
+      namespace 'candidate_topology' do
+        desc 'Post several candiadte topologies'
+        params do
+          requires :usecase, type: String, desc: 'Usecase name'
+          requires :candidate_number, type: Integer, desc: 'Candidate number', default: 1
+        end
+        post do
+          network, snapshot = %i[network snapshot].map { |key| params[key] }
+          base_topology = rest_api.fetch_topology_object(network, snapshot)
+
+          info_list = []
+          (1..params[:candidate_number]).each do |candidate_index|
+            # TODO: generate candidate_i
+            candidate_topology = base_topology.dup
+            # save candidate_i topology
+            candidate_snapshot_name = "original_candidate_#{candidate_index}"
+            rest_api.post_topology_data(network, candidate_snapshot_name, candidate_topology.to_data)
+            info_list.push({ network: network, snapshot: candidate_snapshot_name })
+          end
+
+          # response
+          info_list
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add candidate model api (currently dummy: it returns copy of original_asis as original_candidate)